### PR TITLE
Sec

### DIFF
--- a/functions/sendText.js
+++ b/functions/sendText.js
@@ -1,10 +1,18 @@
 
-const Twilio = require('twilio').twiml.MessagingResponse
+const twilio = require('twilio')
+const TwilioMessagingResponse = twilio.twiml.MessagingResponse
 const DocumentClient = require('aws-sdk/clients/dynamodb').DocumentClient
 const EventBridge = require('aws-sdk/clients/eventbridge')
 const dynamodb = new DocumentClient()
 const eventBridge = new EventBridge()
 const chance = require('chance').Chance()
+const Log = require('@dazn/lambda-powertools-logger')
+const wrap = require('@dazn/lambda-powertools-pattern-basic')
+const { ssm } = require('middy/middlewares')
+
+const serviceName = process.env.service_name
+const stage = process.env.stage
+const endpoint = process.env.twilio_webhook_endpoint
 
 const tableName = process.env.reasons_table
 const busName = process.env.bus_name
@@ -23,7 +31,7 @@ const getReason = async () => {
 
   const resp = await dynamodb.scan(scanParams).promise()
 
-  // If we only get one matching Item from the DB, this means the DB needs to be reset.  Publish an event to EventBridge to trigger another Lambda for that.
+  // Each time a reason is used, we update an attribute for that item in the DB so that it won't be selected again.  If we only get one matching Item from the DB, this means we're at the end of a cycle through all 52 reasons.  We need to update all 52 items so they can be selected again (restart the cycle).  Publish an event to EventBridge to trigger another Lambda for that.
   if (resp.Items.length === 1) {
     const resetId = chance.guid()
     const reasonId = resp.Items[0].id
@@ -48,7 +56,7 @@ const getReason = async () => {
   return resp.Items[0]
 }
 
-// After the first item from the DB response is selected and its "reason" is fed into the Twilio response, update its 3rd column in DynamoDB so that item won't be repeated.
+// After the first item from the DB response is selected and its "reason" is fed into the Twilio response, update its 3rd column in DynamoDB so that item won't be selected again.
 const updateItem = async (reasonId) => {
   console.log(`updating the fetched item so it won't be fetched next time...`)
 
@@ -68,24 +76,62 @@ const updateItem = async (reasonId) => {
   return resp
 }
 
-module.exports.handler = async (event, context, callback) => {
+module.exports.handler = wrap(async (event, context) => {
+
+  const headersArray = Object.values(event.headers)
+  const twilioSignature = headersArray[headersArray.length - 1]
+
+  const urlParams = new URLSearchParams(event.body)
+  const params = Object.fromEntries(urlParams)
+  Log.debug(`Log SMS Msg Received: `, { smsBody: params.Body })
+
+  const requestIsValid = twilio.validateRequest(
+    context.twilioAuthToken,
+    twilioSignature,
+    endpoint,
+    params
+  )
   
-  const twiml = new Twilio()
+  const twiml = new TwilioMessagingResponse()
 
-  if (event.body.includes("mike") || event.body.includes("Mike")) {
-    const dbResponse = await getReason()
-    twiml.message(`${dbResponse.reason}`)
-    await updateItem(dbResponse.id)
-  } else {
-    twiml.message('say my name')
+  let response = {}
+
+  try {
+    // Reject immediately with a standard JSON response if Twilio signature can't be validated
+    if (!requestIsValid) {
+      response.body = "Invalid Request"
+      response.headers = { 'Content-Type': 'application/json' }
+      response.statusCode = 400
+    } else {
+      // After Twilio signature is validated, check that the user's text message content was what it should be
+      if ((params.Body === "mike") || (params.Body === "Mike")) {
+        // Get a Reason from DynamoDB and update its "used" column (attribute) so it won't be selected next time
+        const dbResponse = await getReason()
+        twiml.message(`${dbResponse.reason}`)
+        await updateItem(dbResponse.id)
+      } else {
+        // If the user's text message had the wrong content, prompt them to send the right one
+        twiml.message('say my name')
+      }
+      // Load up the text message response to the user
+      response.body = twiml.toString()
+      response.headers = { 'Content-Type': 'text/xml' }
+      response.statusCode = 200
+    }
+  } catch (e) {
+    response.body = JSON.stringify(e)
+    response.headers = { 'Content-Type': 'application/json' }
+    response.statusCode = 500
   }
-  const response = {
-    statusCode: 200,
-    headers: {
-      'Content-Type': 'text/xml',
-    },
-    body: twiml.toString(),
-  };
 
-callback(null, response);
-}
+  Log.debug('Logging the response: ', { response })
+  return response
+
+}).use(ssm({
+  cache: true,
+  cacheExpiryInMillis: 5 * 60 * 1000,
+  names: {
+    twilioAuthToken: `/${serviceName}/${stage}/twilioAuthToken`
+  },
+  setToContext: true
+}))

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,64 @@
       "integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==",
       "dev": true
     },
+    "@dazn/lambda-powertools-correlation-ids": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-correlation-ids/-/lambda-powertools-correlation-ids-1.24.1.tgz",
+      "integrity": "sha512-03kwqDKpeuPDtOzRl+cGN+1g4AJ5sXubMla+ph4p3FqZRkcCOTWRrNoX+O+NMTRWZOojyhAi+comaoHMaEVY0A=="
+    },
+    "@dazn/lambda-powertools-logger": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-logger/-/lambda-powertools-logger-1.24.1.tgz",
+      "integrity": "sha512-nAYPnF0XWZ/WUY1TA06EFaX35djpCPWpRWIbmQZFBo/AKn8ekR2EpqYKduUTBnbC5IKPiTKFQgfk1togF+RFEg==",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "^1.24.1"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-correlation-ids": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-correlation-ids/-/lambda-powertools-middleware-correlation-ids-1.24.1.tgz",
+      "integrity": "sha512-5+owQuIG4ps1EtYrPr269HkTQBCkfSwnfXuxoNJ0ZJWDbA0g5Ol0N2WmFjxvA5bLzG+DVO3zKdv1Bpq8ub0GSQ==",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "^1.24.1",
+        "@dazn/lambda-powertools-logger": "^1.24.1"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-log-timeout": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-log-timeout/-/lambda-powertools-middleware-log-timeout-1.24.1.tgz",
+      "integrity": "sha512-015W29kYj3bdLWn3EZqcWzJ0Rvn1J3e+CIB6fdIEiaXujfb62zURUrdemufCZzZ8VXo5TZ/o//Qqwsjpk9QP3w==",
+      "requires": {
+        "@dazn/lambda-powertools-logger": "^1.24.1"
+      }
+    },
+    "@dazn/lambda-powertools-middleware-sample-logging": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-middleware-sample-logging/-/lambda-powertools-middleware-sample-logging-1.24.1.tgz",
+      "integrity": "sha512-oTjNCTudG9xwBnl/0TixSFbNZ5G95BOocp7FG3mY+NGpKS7ik0w1fexMbev3dRXecApU8UiEzB/devZkCoUnWQ==",
+      "requires": {
+        "@dazn/lambda-powertools-correlation-ids": "^1.24.1",
+        "@dazn/lambda-powertools-logger": "^1.24.1"
+      }
+    },
+    "@dazn/lambda-powertools-pattern-basic": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@dazn/lambda-powertools-pattern-basic/-/lambda-powertools-pattern-basic-1.24.1.tgz",
+      "integrity": "sha512-AgmCUtRog5laZapS2FRvCtFyEGy2QXOmg6hFi8SR0HzKpZ0xBfjGr9IZN0PBHD6V721NJBpFW6PkKPgRZ+b5NA==",
+      "requires": {
+        "@dazn/lambda-powertools-middleware-correlation-ids": "^1.24.1",
+        "@dazn/lambda-powertools-middleware-log-timeout": "^1.24.1",
+        "@dazn/lambda-powertools-middleware-sample-logging": "^1.24.1",
+        "@middy/core": "^1.0.0"
+      }
+    },
+    "@middy/core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-1.0.0.tgz",
+      "integrity": "sha512-97niLTWQMK/zixQoFdkpVzskxkkj5r+TdYABOHFN1GittBcqVFZ/4dEKissmL1eQASIb/70RpHlbcDxWQfoPCA==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "serverless-pseudo-parameters": "^2.5.0"
   },
   "dependencies": {
+    "@dazn/lambda-powertools-logger": "^1.24.1",
+    "@dazn/lambda-powertools-pattern-basic": "^1.24.1",
     "chance": "^1.1.6",
     "middy": "^0.36.0",
     "twilio": "^3.45.0"

--- a/serverless.yml
+++ b/serverless.yml
@@ -25,6 +25,14 @@ functions:
     environment:
       reasons_table: !Ref ReasonsTable
       bus_name: !Ref EventBus
+      service_name: ${self:service}
+      stage: ${self:custom.stage}
+      twilio_webhook_endpoint:
+        Fn::Join:
+          - ""
+          - - https://
+            - !Ref ApiGatewayRestApi
+            - .execute-api.${self:provider.region}.amazonaws.com/${self:custom.stage}/sendText
     iamRoleStatements:
       - Effect: Allow
         Action: execute-api:Invoke
@@ -37,7 +45,10 @@ functions:
       - Effect: Allow
         Action: events:PutEvents
         Resource: "*"
-        
+      - Effect: Allow
+        Action: ssm:GetParameters*
+        Resource:
+          - arn:aws:ssm:#{AWS::Region}:#{AWS::AccountId}:parameter/${self:service}/${self:custom.stage}/twilioAuthToken
 
   resetReasons:
     handler: functions/resetReasons.handler


### PR DESCRIPTION
Refactor:

- Add Twilio signature verification to the webhook's Lambda.  There's a lot going on in the webhook's lambda.  For a project this small,  I don't see a compelling reason to split this functionality out and create multiple cold starts.  Looked into API GW custom authorizer functions, but they don't have access to the request body, which is needed for Twilio signature verification.  For this project, it's fine as is.

- Add SSM permission in serverless.yml so we can securely load Twilio Auth Token at runtime.  

- Add API GW webhook endpoint as env var in serverless.yml so that it can be fed into Twilio Signature verification in the Lambda without hardcoding.